### PR TITLE
Fix tailwind css not working

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -2,22 +2,6 @@
 export default {
 	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
 	theme: {
-		colors: {
-			'primary': '#a1b5a0',
-			'secondary' : '#f2e9e1',
-			'tertiary': '#5a5a4e',
-			'accent': '#E07A5F',
-			'accent-dark': '#C85D46',
-			'white': '#fff',
-			'black': '#000',
-			'black-dark': '#000',
-			'transparent': 'transparent',
-			        // Ajout pour "Derniers articles"
-			'articles-bg': '#F9F5EE',    // Beige Pâle (Fond des articles)
-			'articles-title': '#365943', // Brun Foncé (Titre de la section articles)
-			'articles-item': '#4C7C5F',  // Vert Foncé (Titres des articles)
-			'articles-date': '#7A431F',  // Orange Clair (Date des articles)
-		},
 		container: {
 			center: true,
 			padding: {
@@ -26,7 +10,21 @@ export default {
 				lg: '5rem',
 			},
 		},
-		extend: {},
+		extend: {
+			colors: {
+				'primary': '#a1b5a0',
+				'secondary' : '#f2e9e1',
+				'tertiary': '#5a5a4e',
+				'accent': '#E07A5F',
+				'accent-dark': '#C85D46',
+				'black-dark': '#000',
+				// Ajout pour "Derniers articles"
+				'articles-bg': '#F9F5EE',    // Beige Pâle (Fond des articles)
+				'articles-title': '#365943', // Brun Foncé (Titre de la section articles)
+				'articles-item': '#4C7C5F',  // Vert Foncé (Titres des articles)
+				'articles-date': '#7A431F',  // Orange Clair (Date des articles)
+			}
+		},
 	},
 	plugins: [],
 }


### PR DESCRIPTION
Move custom Tailwind colors to `theme.extend.colors` to correctly merge with default colors.

The previous configuration in `tailwind.config.mjs` was replacing the entire default color palette, causing Tailwind utility classes that rely on default colors (e.g., `from-blue-50`, `to-white`) to fail. This change ensures both default and custom colors are available.

---
<a href="https://cursor.com/background-agent?bcId=bc-40b7f17e-5fe3-4dd3-8079-f8e8c7a0a5c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40b7f17e-5fe3-4dd3-8079-f8e8c7a0a5c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

