### PR TITLE
Fix blog structured data rendering

### DIFF
--- a/src/components/BlogSchema.astro
+++ b/src/components/BlogSchema.astro
@@ -9,20 +9,18 @@ interface Props {
 
 const { title, description, pubDate, slug, author = "Nicolas Devaux" } = Astro.props;
 const url = new URL(`/blog/${slug}/`, Astro.site);
----
 
-<script type="application/ld+json" is:inline>
-{
+const blogJsonLd = {
   "@context": "https://schema.org",
   "@type": "BlogPosting",
-  "headline": {JSON.stringify(title)},
-  "description": {JSON.stringify(description)},
-  "url": {JSON.stringify(url.toString())},
-  "datePublished": {JSON.stringify(pubDate.toISOString())},
-  "dateModified": {JSON.stringify(pubDate.toISOString())},
+  "headline": title,
+  "description": description,
+  "url": url.toString(),
+  "datePublished": pubDate.toISOString(),
+  "dateModified": pubDate.toISOString(),
   "author": {
     "@type": "Person",
-    "name": {JSON.stringify(author)},
+    "name": author,
     "jobTitle": "Psychologue clinicien",
     "worksFor": {
       "@type": "MedicalBusiness",
@@ -40,7 +38,7 @@ const url = new URL(`/blog/${slug}/`, Astro.site);
   },
   "mainEntityOfPage": {
     "@type": "WebPage",
-    "@id": {JSON.stringify(url.toString())}
+    "@id": url.toString()
   },
   "keywords": [
     "psychologie",
@@ -61,7 +59,7 @@ const url = new URL(`/blog/${slug}/`, Astro.site);
       "name": "Troubles anxieux"
     },
     {
-      "@type": "MedicalCondition", 
+      "@type": "MedicalCondition",
       "name": "Dépression"
     },
     {
@@ -76,5 +74,7 @@ const url = new URL(`/blog/${slug}/`, Astro.site);
       "url": "https://nicolas-devaux-psychologue.fr"
     }
   ]
-}
-</script>
+};
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(blogJsonLd)} />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import BaseHead from "../components/BaseHead.astro";
+import BlogSchema from "../components/BlogSchema.astro";
 import Header from "../components/Header.astro";
 import Breadcrumb from "../components/Breadcrumb.astro";
 import Footer from "../components/Footer.astro";
@@ -21,11 +22,14 @@ const {
   blogPost = false,
   showDate = true,
 } = Astro.props;
+
+const slug = Astro.url.pathname.replace(/^\/blog\//, "").replace(/\/$/, "");
 ---
 
 <html lang="fr">
   <head>
     <BaseHead title={title} description={description} />
+    {blogPost && <BlogSchema title={title} description={description} pubDate={pubDate} slug={slug} />}
   </head>
 
   <body class="bg-gradient-to-r from-blue-50 to-white">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -15,6 +15,6 @@ const post = Astro.props;
 const { Content } = await post.render();
 ---
 
-<BlogPost {...post.data}>
+<BlogPost {...post.data} blogPost={true}>
 	<Content />
 </BlogPost>


### PR DESCRIPTION
### Motivation
- The `BlogSchema` component previously attempted to interpolate props directly inside a `<script>` block, which prevented the `BlogPosting` JSON-LD from being reliably produced and caused build-time “unused” prop warnings. 
- Article pages were not wired to render the blog-specific schema because the blog layout was not always invoked in blog mode. 

### Description
- Rewrote `src/components/BlogSchema.astro` to build a `blogJsonLd` JavaScript object and inject it with `set:html` instead of using inline string interpolation. 
- Added an import and conditional render of `<BlogSchema />` to the head of `src/layouts/BlogPost.astro`, and derive the `slug` from `Astro.url.pathname` for a correct canonical URL. 
- Enabled blog-mode rendering by setting `blogPost={true}` in `src/pages/blog/[...slug].astro` so article pages include the `BlogPosting` schema. 
- Cleaned up the structured-data injection so `datePublished`, `dateModified`, `author.name`, and page `@id` are serialized as proper values (not literal `{JSON.stringify(...)}` tokens). 

### Testing
- Ran `npm run build` (which runs `astro check && astro build`) and the build completed successfully with no errors. 
- Verified the generated HTML under `dist/blog/...` contains the `application/ld+json` `BlogPosting` entry by scanning the built files with a small script/regex, confirming the schema is present in article pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e106275b4832dbd3115ee3aa13ee6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SEO-only changes to JSON-LD rendering and layout wiring; minimal behavioral impact beyond generated HTML in blog pages.
> 
> **Overview**
> Fixes blog structured data by rebuilding `BlogSchema.astro` as a `blogJsonLd` object and injecting it via `set:html`, ensuring values like `headline`, dates, author name, and `@id` serialize correctly.
> 
> Wires the schema into blog pages by conditionally rendering `BlogSchema` in `BlogPost.astro` when `blogPost` is true, deriving `slug` from `Astro.url.pathname`, and setting `blogPost={true}` in `pages/blog/[...slug].astro`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fe475cd881ea940fc634d4ddb5e40448783590d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->