### PR TITLE
Ajouter une section de liens internes à la page TCC

### DIFF
--- a/src/pages/therapie-cognitive-et-comportementale.astro
+++ b/src/pages/therapie-cognitive-et-comportementale.astro
@@ -124,5 +124,30 @@ import TccImage from "../assets/tcc-landscape.webp";
         entre 12 et 25 séances, selon les problématiques abordées.
       </p>
     </div>
+
+    <div>
+      <h2 class="mb-5">Pages à consulter</h2>
+      <p>
+        Pour approfondir cette approche et voir comment elle s'intègre dans mon
+        accompagnement, vous pouvez également consulter :
+      </p>
+      <ul class="list-disc ml-6 mt-2">
+        <li>
+          <a href="/psychotherapie/" class="text-link"
+            >Psychothérapie : cadre général de l'accompagnement</a
+          >
+        </li>
+        <li>
+          <a href="/consulter/" class="text-link"
+            >Quand et pourquoi consulter un psychologue</a
+          >
+        </li>
+        <li>
+          <a href="/mon-soutien-psy/" class="text-link"
+            >Mon soutien psy : informations pratiques</a
+          >
+        </li>
+      </ul>
+    </div>
   </section>
 </Layout>


### PR DESCRIPTION
### Motivation
- Améliorer la navigation interne et le maillage interne de la page « Thérapie cognitive et comportementale » pour faciliter l'accès aux pages connexes et renforcer la cohérence du site.

### Description
- Ajout d'une section `Pages à consulter` à la fin de `src/pages/therapie-cognitive-et-comportementale.astro` contenant trois liens internes vers `/psychotherapie/`, `/consulter/` et `/mon-soutien-psy/`.

### Testing
- Exécution de la commande `npm run build` qui a abouti sans erreurs.
- Lancement du serveur de développement et capture de la page via Playwright pour vérification visuelle, qui a confirmé la présence de la nouvelle section.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac77f607b0832d99e0c018e6a9a1c0)