### PR TITLE
Improve `.text-link` accessibility contrast on light backgrounds

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -189,13 +189,19 @@ img {
 }
 
 .text-link {
-    color: var(--accent);
+    color: #7A431F;
     transition: color 0.3s ease-out;
     text-decoration: underline;
+    text-decoration-thickness: 0.08em;
+    text-underline-offset: 0.12em;
 }
 
 .text-link:hover {
-    color: var(--accent-dark);
+    color: #5C2F14;
+}
+
+.text-link:focus-visible {
+    color: #5C2F14;
 }
 
 .c-wysiwig h2 {


### PR DESCRIPTION
### Motivation
- Links using the `.text-link` class had insufficient foreground/background contrast on light backgrounds, reducing accessibility and readability.

### Description
- Updated `.text-link` color from the previous accent variable to a darker brown `#7A431F` to increase contrast on light backgrounds.
- Added `text-decoration-thickness: 0.08em` and `text-underline-offset: 0.12em` to improve underline visibility without changing layout.
- Harmonized interactive states by setting both `:hover` and `:focus-visible` to a darker shade `#5C2F14` for clearer feedback.

### Testing
- Ran `npm run build` which completed successfully with no errors.
- Launched the dev server and captured a headless screenshot of `/consulter/` to verify the visual result; the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8769551c832daaf77ec850c1f9f4)