### PR TITLE
Prevent Cloudflare email obfuscation causing /cdn-cgi 404 links

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -50,6 +50,7 @@ const umamiUrl = import.meta.env.PUBLIC_UMAMI_URL;
 
 <!-- Schema.org structured data (prod only to keep dev tools stable) -->
 {import.meta.env.PROD && (
+<!--email_off-->
 <script type="application/ld+json" is:inline>
 {
   "@context": "https://schema.org",
@@ -267,6 +268,7 @@ const umamiUrl = import.meta.env.PUBLIC_UMAMI_URL;
 }
 
 </script>
+<!--/email_off-->
 )}
 
 {umamiId && umamiUrl && (

--- a/src/pages/mentions-legales.astro
+++ b/src/pages/mentions-legales.astro
@@ -23,7 +23,7 @@ import Layout from "../layouts/BlogPost.astro";
       <li>Email : <span x-data="{ revealed: false }"
           @click="revealed = true"
           :class="{ 'cursor-pointer underline': !revealed }">
-          <span x-text="revealed ? 'ndevaux@gmail.com' : 'Cliquez pour afficher'"></span>
+          <span x-text="revealed ? ['ndevaux','gmail.com'].join('@') : 'Cliquez pour afficher'"></span>
       </span></li>
     </ul>
     <p>Directeur de la publication : Nicolas Devaux.</p>


### PR DESCRIPTION
### Motivation
- Cloudflare can rewrite literal email addresses (including those inside JSON-LD) into `/cdn-cgi/l/email-protection/...`, which may produce broken links or 404s when the decoding script is unavailable.

### Description
- Wrapped the production JSON-LD block in `src/components/BaseHead.astro` with Cloudflare markers `<!--email_off-->` and `<!--/email_off-->` to stop Cloudflare from rewriting schema email values.
- Replaced the inline email string in `src/pages/mentions-legales.astro` with a runtime-constructed expression (`['ndevaux','gmail.com'].join('@')`) so the raw address is not present in the generated HTML source.
- Changes touch two files: `src/components/BaseHead.astro` and `src/pages/mentions-legales.astro`.

### Testing
- Ran `npm run build`, which completed successfully (Astro check passed and static build produced the expected pages).
- No additional automated browser or integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c22e77c928832dbe064b96690167e7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts HTML output to avoid Cloudflare email rewriting; no business logic or data handling changes, but could affect SEO parsers if markers are misinterpreted.
> 
> **Overview**
> Prevents Cloudflare’s email obfuscation from rewriting email addresses into broken `/cdn-cgi/l/email-protection/...` links.
> 
> In `BaseHead.astro`, wraps the production JSON-LD `<script>` block with `<!--email_off-->` / `<!--/email_off-->` so schema email fields are left untouched. In `mentions-legales.astro`, changes the revealed email to be constructed at runtime (`['ndevaux','gmail.com'].join('@')`) so the raw address isn’t present in the generated HTML.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6939135f5ada43c08db88f2f8cc8947acdd6266b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->