### PR TITLE
Use each blog post hero image for og:image metadata

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -31,7 +31,7 @@ const slug = Astro.url.pathname.replace(/^\/blog\//, "").replace(/\/$/, "");
 
 <html lang="fr">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead title={title} description={description} image={heroImage?.src} />
     {blogPost && <BlogSchema title={title} description={description} pubDate={pubDate} slug={slug} />}
   </head>
 


### PR DESCRIPTION
### Motivation
- Ensure each blog article uses its declared `heroImage` for Open Graph and Twitter previews instead of falling back to the default placeholder image.

### Description
- Pass `heroImage?.src` from `src/layouts/BlogPost.astro` into the `<BaseHead>` component so the `og:image` and `twitter:image` metadata use the article's own image.

### Testing
- Ran `npm run build` successfully and inspected the generated `dist/blog/*/index.html` files to confirm each page's `<meta property="og:image">` now references the article's optimized `_astro/...` image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3ada54990832d8f0ec6e0ce03198a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small metadata-only change that wires an existing `heroImage` into `BaseHead` without affecting rendering or data flow beyond meta tags.
> 
> **Overview**
> Blog post pages now provide `heroImage?.src` to `BaseHead`, causing `og:image` and `twitter:image` meta tags to reference each article’s hero image rather than the default placeholder.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cbd4a07b593f1a9fc97fe671dfe1918efba45ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->