### PR TITLE
Fix mobile horizontal overflow

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,6 +44,11 @@
 
 html {
     scroll-behavior: smooth;
+    overflow-x: hidden;
+}
+
+body {
+    overflow-x: hidden;
 }
 
 :target {


### PR DESCRIPTION
### Motivation
- A horizontal scrollbar appeared on small screens because some element(s) could overflow the viewport, so a global overflow guard was needed to remove unintended horizontal scrolling.

### Description
- Added `overflow-x: hidden` to both `html` and `body` in `src/styles/global.css` to prevent horizontal overflow on mobile devices.

### Testing
- Ran `npm run -s build`; the build completed successfully and Astro diagnostics reported `0 errors` and `0 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffaed271a0832d8a01666a26d4e834)