### PR TITLE
Supprime le fix global et ajuste la mise en page du hero pour éviter le scroll horizontal mobile

### DIFF
--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -36,28 +36,26 @@ import { NEARBY_CITIES } from "../consts";
       </p>
 
       <nav class="flex flex-col gap-4" aria-label="Propositions thérapeutiques">
-        <div class="flex flex-col sm:flex-row sm:flex-wrap gap-4 sm:gap-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 max-w-3xl">
           <!-- Approches thérapeutiques principales -->
-          <div class="flex gap-2">
             <a
               href="/therapie-mosaic/"
-              class="inline-flex w-fit items-center rounded-lg border border-primary/30 bg-primary/8 px-4 py-2.5 text-sm font-semibold text-tertiary no-underline transition-colors duration-200 hover:bg-primary/16 hover:border-primary/50"
+              class="inline-flex w-full items-center rounded-lg border border-primary/30 bg-primary/8 px-4 py-2.5 text-sm font-semibold text-tertiary no-underline transition-colors duration-200 hover:bg-primary/16 hover:border-primary/50"
             >
               Thérapie MOSAIC
             </a>
             <a
               href="/psychotherapie/"
-              class="inline-flex w-fit items-center rounded-lg border border-primary/30 bg-primary/8 px-4 py-2.5 text-sm font-semibold text-tertiary no-underline transition-colors duration-200 hover:bg-primary/16 hover:border-primary/50"
+              class="inline-flex w-full items-center rounded-lg border border-primary/30 bg-primary/8 px-4 py-2.5 text-sm font-semibold text-tertiary no-underline transition-colors duration-200 hover:bg-primary/16 hover:border-primary/50"
             >
               Psychothérapies intégratives
             </a>
             <a
               href="/tcc-troisieme-vague/"
-              class="inline-flex w-fit items-center rounded-lg border border-primary/30 bg-primary/8 px-4 py-2.5 text-sm font-semibold text-tertiary no-underline transition-colors duration-200 hover:bg-primary/16 hover:border-primary/50"
+              class="inline-flex w-full items-center rounded-lg border border-primary/30 bg-primary/8 px-4 py-2.5 text-sm font-semibold text-tertiary no-underline transition-colors duration-200 hover:bg-primary/16 hover:border-primary/50"
             >
               Thérapies Cognitives et Comportementales (TCC)
             </a>
-          </div>
         </div>
       </nav>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,11 +44,6 @@
 
 html {
     scroll-behavior: smooth;
-    overflow-x: hidden;
-}
-
-body {
-    overflow-x: hidden;
 }
 
 :target {


### PR DESCRIPTION
### Motivation
- Le correctif global `overflow-x: hidden` masquait le débordement au lieu de corriger la cause (éléments dépassant le viewport). 
- L’objectif est d’éviter le scroll horizontal sur mobile en réorganisant les éléments qui débordent plutôt qu’en les masquant.

### Description
- Supprime les règles `overflow-x: hidden` sur `html`/`body` dans `src/styles/global.css` pour rétablir le comportement de scroll natif. 
- Remplace le conteneur flex des liens d’approches thérapeutiques dans `src/components/HeroSection.astro` par une grille responsive `grid grid-cols-1 sm:grid-cols-2` et passe les liens en `w-full` afin qu’ils soient empilés sur mobile et affichés deux par ligne à partir de `sm`. 
- Ajuste les classes utilitaires pour alléger le wrapping et prévenir le débordement horizontal sans recourir à un masquage global.

### Testing
- Exécuté `npm run build` (inclut `astro check && astro build`) et la build a réussi sans erreurs. 
- `astro check` a renvoyé `0 errors` lors du build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb11f45cc832dba0aa53cf0cd4e12)