### PR TITLE
Corrige les libellés du questionnaire des Schémas de Young

### DIFF
--- a/src/pages/outils/questionnaire-schemas-young.astro
+++ b/src/pages/outils/questionnaire-schemas-young.astro
@@ -33,7 +33,7 @@ const description = "Passez le Questionnaire des Schémas de Young en ligne — 
       <h1 class="font-display typo-h1 mb-2 text-pretty text-ink-primary md:mb-3">
         Questionnaire des Schémas de Young
       </h1>
-      <p class="mb-6 text-sm text-ink-tertiary">Version 1994, traduction J. Cottraux (1995, révisée 1999)</p>
+      <p class="mb-6 text-sm text-ink-tertiary">Version YSQ-L3, traduction par Pierre Cousineau et Bernard Pascal</p>
 
       <div class="rounded-xl border border-border-subtle bg-secondary/40 p-5 md:p-6">
         <SectionHeading class="mb-4" eyebrow="01 — Consignes" title="Instructions" />
@@ -44,12 +44,12 @@ const description = "Passez le Questionnaire des Schémas de Young en ligne — 
         </p>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
           {[
-            [1, "Cela ne m'a jamais correspondu tout au long de ma vie"],
-            [2, "Cela a été vrai pour une période de ma vie, mais pas la plupart du temps"],
-            [3, "Cela me concerne en ce moment, mais généralement pas au cours de ma vie"],
-            [4, "Assez vrai pour moi durant la majeure partie de ma vie"],
-            [5, "Tout à fait vrai pour moi la majeure partie de ma vie"],
-            [6, "Me décrit parfaitement tout au long de ma vie"],
+            [1, "Cela est complètement faux pour moi"],
+            [2, "Le plus souvent faux pour moi"],
+            [3, "Plutôt vrai que faux pour moi"],
+            [4, "Assez vrai pour moi"],
+            [5, "Le plus souvent vrai pour moi"],
+            [6, "Me décrit parfaitement"],
           ].map(([n, label]) => (
             <div class="flex items-start gap-2.5">
               <span class="font-ui shrink-0 w-6 h-6 rounded-full bg-surface-raised border border-border-strong flex items-center justify-center text-xs font-medium text-tertiary">{n}</span>


### PR DESCRIPTION
### Motivation
- Aligner l'échelle de réponse et la mention de version/traduction du questionnaire avec la formulation de la source de référence (YSQ-L3 / IFTS).

### Description
- Met à jour la ligne d'en-tête affichant la version/traduction en `Version YSQ-L3, traduction par Pierre Cousineau et Bernard Pascal` dans `src/pages/outils/questionnaire-schemas-young.astro`.
- Remplace les 6 libellés de l'échelle de cotation (1–6) par les formulations de référence : `"Cela est complètement faux pour moi"`, `"Le plus souvent faux pour moi"`, `"Plutôt vrai que faux pour moi"`, `"Assez vrai pour moi"`, `"Le plus souvent vrai pour moi"`, `"Me décrit parfaitement"`.

### Testing
- Examen du diff via `git diff -- src/pages/outils/questionnaire-schemas-young.astro` (succès).
- Ajout et commit du fichier modifié avec `git add` + `git commit -m "Corrige les libellés du questionnaire Young selon la source IFTS"` (succès).
- Vérification du hash de commit via `git rev-parse --short HEAD` (succès, commit `056e3e8`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bcbcb9d8832dbbf92e20db25bd4e)